### PR TITLE
Refactor: cell_* methods

### DIFF
--- a/gridit/file.py
+++ b/gridit/file.py
@@ -178,7 +178,7 @@ def write_vector(
         driver = driver_from_extension(fname)
         grid.logger.debug("driver from extension: %s", driver)
 
-    geoms = grid.cell_geoms
+    geoms = grid.cell_geoms()
     idxs = np.arange(geoms.size)
     if np.ma.isMA(array) and array.mask.any():
         sel2d = (~array.mask).any(0)

--- a/gridit/spatial.py
+++ b/gridit/spatial.py
@@ -73,8 +73,8 @@ def flat_grid_intersect(this, other, method="vector"):
             shapely.__version__)
         if this_crs != other_crs:
             logger.warning("ignoring different CRS from grids")
-        this_geoms = this.cell_geoms
-        other_geoms = other.cell_geoms
+        this_geoms = this.cell_geoms()
+        other_geoms = other.cell_geoms()
         classic_shapely = shapely.__version__.startswith("1.")
         same_resolution = this.resolution == other.resolution
         if classic_shapely:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,7 @@ def test_grid_from_bbox_array_from_raster(tmp_path, grid_from_bbox_args):
     assert out_path.exists()
 
 
-@requires_pkg("fiona")
+@requires_pkg("fiona", "rasterio")
 def test_grid_from_bbox_array_from_vector(grid_from_bbox_args):
     stdout, stderr, returncode = run_cli(
         grid_from_bbox_args +


### PR DESCRIPTION
This is a breaking revision from #10 and #11.

- Change `cell_geoms` to a function with options `mask` and `order`
- Remove `zero_based` option, add `order`