### PR TITLE
hack so that from_modflow can be called with just the modelgrid obj

### DIFF
--- a/gridit/modflow.py
+++ b/gridit/modflow.py
@@ -12,6 +12,11 @@ def get_modflow_model(model, model_name=None, logger=None):
     """Return model object from str or Path."""
     import flopy
 
+    if hasattr(model, "xoffset"):
+        from types import SimpleNamespace
+        tmpobj = SimpleNamespace()
+        tmpobj.modelgrid = model
+        return tmpobj  # dummy object with a modelgrid atrib
     if hasattr(model, "modelgrid"):
         return model
     elif not isinstance(model, (str, Path)):
@@ -116,10 +121,7 @@ def from_modflow(
         else:
             projection = ""
     # also cache mask while we are here
-    if hasattr(model, "bas6"):
-        domain = model.bas6.ibound.array
-    else:
-        domain = model.dis.idomain.array
+    domain = modelgrid.idomain
     mask = (domain == 0).all(0)
     mask_cache[mask_cache_key] = mask
     return cls(

--- a/gridit/modflow.py
+++ b/gridit/modflow.py
@@ -73,7 +73,7 @@ def from_modflow(
 
     Parameters
     ----------
-    model : str, Path, flopy.modflow.Modflow, or flopy.mf6.mfmodel.MFModel
+    model : str, Path, flopy.modflow.Modflow, flopy.mf6.mfmodel.MFModel or flopy.discretization.grid
         MODFLOW model specified either as a FloPy object, or path to
         a MODFLOW file.
     model_name : str or None (default)

--- a/tests/test_modflow.py
+++ b/tests/test_modflow.py
@@ -48,6 +48,7 @@ def test_grid_from_modflow_classic():
 
 @requires_pkg("flopy")
 def test_grid_from_modflow_6(caplog):
+    from gridit.modflow import get_modflow_model
     expected = Grid(1000.0, (18, 17), (1802000.0, 5879000.0))
 
     with caplog.at_level(logging.WARNING):
@@ -69,6 +70,13 @@ def test_grid_from_modflow_6(caplog):
     # also rasises logger warning
     grid = Grid.from_modflow(modflow_dir)
     assert grid == expected
+
+    # test with modelgrid object
+    model = get_modflow_model(modflow_dir / "mfsim.nam")
+    grid = Grid.from_modflow(model.modelgrid)
+    assert grid.projection == ""
+    assert grid.shape == (18, 17)
+    assert grid.resolution == 1000.
 
 
 @requires_pkg("flopy")


### PR DESCRIPTION
Handy to not need to rely on a whole flopy mudflow model instance when all we need is the modelgrid atrib.

Light mod to support this. Addresses #19  