### PR TITLE
Feature: allow kwargs for raster/vector creation options

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,6 +63,7 @@ def test_grid_from_bbox_array_from_raster(tmp_path, grid_from_bbox_args):
             "--array-from-raster", str(mana_tif) + ":1",
             "--array-from-raster-resampling", "nearest",
             "--write-raster", str(out_path),
+            "--write-creation-option", "COMPRESS=deflate",
         ]
     )
     # fmt: on
@@ -119,6 +120,26 @@ def test_grid_from_bbox_array_from_vector_attribute(tmp_path, grid_from_bbox_arg
     if expected_properties != resulting_properties:
         expected_properties["kmd"] = "float:18.16"
     assert expected_properties == resulting_properties
+
+
+@requires_pkg("fiona")
+def test_write_csv(tmp_path, grid_from_bbox_args):
+    out_csv = tmp_path / "out.csv"
+    # fmt: off
+    stdout, stderr, returncode = run_cli(
+        grid_from_bbox_args
+        + [
+            "--array-from-vector", mana_shp,
+            "--array-from-vector-attribute", "K_m_d",
+            "--write-vector", str(out_csv),
+            "--write-creation-option", "GEOMETRY=AS_WKT",
+        ]
+    )
+    # fmt: on
+    assert len(stderr) == 0
+    assert len(stdout) > 0
+    assert returncode == 0
+    assert out_csv.read_text().splitlines()[0] == "WKT,idx,row,col,value"
 
 
 @requires_pkg("fiona", "netcdf4", "xarray")

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -74,13 +74,14 @@ def test_write_raster(tmp_path, grid_basic, grid_projection, masked):
         assert ar.dtype == np.float32
         assert ar.shape == (1, 20, 30)
         np.testing.assert_array_almost_equal(ar[0], ar_float32)
+        assert ds.compression is None
 
     ar_float64 = np.arange(20 * 30, dtype=np.float64).reshape((20, 30))
     if masked:
         ar_float64 = np.ma.array(ar_float64)
         ar_float64.fill_value = -1.0
     fname = tmp_path / "float64.tif"
-    grid_basic.write_raster(ar_float64, fname)
+    grid_basic.write_raster(ar_float64, fname, COMPRESS="DEFLATE")
     with rasterio.open(fname) as ds:
         assert not ds.crs
         if masked:
@@ -91,6 +92,7 @@ def test_write_raster(tmp_path, grid_basic, grid_projection, masked):
         assert ar.dtype == np.float64
         assert ar.shape == (1, 20, 30)
         np.testing.assert_array_almost_equal(ar[0], ar_float64)
+        assert ds.compression == rasterio.enums.Compression.deflate
 
     ar_uint16 = np.arange(20 * 30, dtype=np.uint16).reshape((20, 30)) + 1
     if masked:
@@ -257,6 +259,10 @@ def test_write_vector(tmp_path, grid_basic, grid_projection):
             "nums1": 2995,
             "nums2": 5995,
         }
+
+    csv_fname = tmp_path / "default.csv"
+    grid_basic.write_vector(ar_int[0], csv_fname, "nums1", GEOMETRY="AS_WKT")
+    assert csv_fname.read_text().splitlines()[0] == "WKT,idx,row,col,nums1"
 
     # errors
     ar2d = np.ones(20 * 30).reshape((20, 30))


### PR DESCRIPTION
This feature is handy to send creation options to GDAL/OGR drivers when writing rasters or vectors.