### PR TITLE
Refactor array_from_vector method for Polygon without attribute

### DIFF
--- a/src/gridit/__main__.py
+++ b/src/gridit/__main__.py
@@ -132,12 +132,6 @@ Examples:
             ),
         )
         array_from_vector_group.add_argument(
-            "--array-from-vector-calc",
-            metavar="CALC",
-            default=None,
-            help="Not implemented yet.",
-        )
-        array_from_vector_group.add_argument(
             "--array-from-vector-fill",
             metavar="FILL",
             default=0,
@@ -486,7 +480,6 @@ Examples:
                 fname,
                 layer=layer,
                 attribute=args.array_from_vector_attribute,
-                calc=args.array_from_vector_calc,
                 fill=args.array_from_vector_fill,
                 refine=args.array_from_vector_refine,
                 all_touched=args.all_touched,

--- a/tests/test_array_from.py
+++ b/tests/test_array_from.py
@@ -399,12 +399,17 @@ def test_array_from_vector(
     assert ar.shape == (24, 18)
     assert np.ma.isMaskedArray(ar)
     if attribute is None:
+        uvals = set(np.unique(ar).filled().tolist())
         if refine > 1:
             assert ar.dtype == np.float32
+            if refine == 2:
+                assert uvals == {0.0, 0.25, 0.5, 0.75, 1.0}
+            else:
+                assert len(uvals) > 5
         else:
             assert ar.dtype == np.uint8
+            assert uvals == {0, 1}
         assert ar.fill_value == 0
-        assert set(np.unique(ar).filled()) == {0, 1}
     else:
         assert np.issubdtype(ar.dtype, np.floating)
         assert ar.fill_value == 0.0


### PR DESCRIPTION
This is a follow-up on #58 to further refactor `array_from_vector()` when refine > 1 with Polygons and attribute is not specified. The changed behaviour is that the values may range intervals between 0 and 1, rather than just 0 and 1.

Other changes:

- Remove unused `calc` / `--array-from-vector-calc`